### PR TITLE
fix js for other players when discarding limits

### DIFF
--- a/modules/js/states/handLimit.js
+++ b/modules/js/states/handLimit.js
@@ -82,7 +82,7 @@ define(["dojo", "dojo/_base/declare"], (dojo, declare) => {
       var player_id = notif.args.player_id;
       var cards = notif.args.cards;
 
-      if (this.isCurrentPlayerActive()) {
+      if (player_id == this.player_id) {
         this.discardCards(cards, this.handStock);
       } else {
         this.discardCards(cards, undefined, player_id);

--- a/modules/js/states/keepersLimit.js
+++ b/modules/js/states/keepersLimit.js
@@ -84,7 +84,7 @@ define(["dojo", "dojo/_base/declare"], (dojo, declare) => {
       var player_id = notif.args.player_id;
       var cards = notif.args.cards;
 
-      if (this.isCurrentPlayerActive()) {
+      if (player_id == this.player_id) {
         this.discardCards(cards, this.handStock);
       } else {
         this.discardCards(cards, undefined, player_id);


### PR DESCRIPTION
hi, I merged everything and was checking some sanity test game, and I noticed that other players got js error when 1 player was discarding.
Apparently some isCurrentPlayerActive still remained in these multistate transition.

Btw, I also see strange behavior in the messages for the hand and keeper limits: at first, all players get the same number as the current player in the message "You must discard X cards for hand/keeper limit Y".
So the "X" is the same for all players, and is the number that actually the player that played the turn has to discard.

But when I do F5 refresh on each tab, all players do get their own correct to discard count.
And I can't see anything wrong with the argHandLimit / argKeeperLimit functions...

Maybe this is some side-effect of the "Express Start" studio feature where 1 browser is impersonating all the test users.
Or maybe there is still some bug...
