### PR TITLE
fix limit issues

### DIFF
--- a/modules/js/states/handLimit.js
+++ b/modules/js/states/handLimit.js
@@ -23,14 +23,14 @@ define(["dojo", "dojo/_base/declare"], (dojo, declare) => {
           "onSelectCardHandLimit"
         );
 
-        this.discardCountHandLimit = args.nb;
-      }
+        this.discardCountHandLimit = args._private.nb;
 
-      this.addActionButton(
-        "button_1",
-        _("Discard selected"),
-        "onRemoveCardsHandLimit"
-      );
+        this.addActionButton(
+          "button_1",
+          _("Discard selected"),
+          "onRemoveCardsHandLimit"
+        );
+      }
     },
 
     onLeavingStateHandLimit: function () {

--- a/modules/js/states/keepersLimit.js
+++ b/modules/js/states/keepersLimit.js
@@ -22,14 +22,14 @@ define(["dojo", "dojo/_base/declare"], (dojo, declare) => {
           this,
           "onSelectCardKeepersLimit"
         );
-        this.discardCountKeepersLimit = args.nb;
-      }
+        this.discardCountKeepersLimit = args._private.nb;
 
-      this.addActionButton(
-        "button_1",
-        _("Discard selected"),
-        "onRemoveCardsKeepersLimit"
-      );
+        this.addActionButton(
+          "button_1",
+          _("Discard selected"),
+          "onRemoveCardsKeepersLimit"
+        );
+      }
     },
 
     onLeavingStateKeepersLimit: function () {
@@ -84,11 +84,7 @@ define(["dojo", "dojo/_base/declare"], (dojo, declare) => {
       var player_id = notif.args.player_id;
       var cards = notif.args.cards;
 
-      if (player_id == this.player_id) {
-        this.discardCards(cards, this.handStock);
-      } else {
-        this.discardCards(cards, undefined, player_id);
-      }
+      this.discardCards(cards, this.keepersStock[player_id]);
 
       this.keepersCounter[player_id].toValue(
         this.keepersStock[player_id].count()

--- a/states.inc.php
+++ b/states.inc.php
@@ -117,7 +117,7 @@ $machinestates = [
       'Other players must discard cards for Hand Limit ${limit}'
     ),
     "descriptionmyturn" => clienttranslate(
-      '${you} must discard ${nb} cards for Hand Limit ${limit}'
+      '${you} must discard ${_private.nb} cards for Hand Limit ${limit}'
     ),
     "type" => "multipleactiveplayer",
     "args" => "argHandLimit",
@@ -132,7 +132,7 @@ $machinestates = [
       'Other players must remove keepers for Keeper Limit ${limit}'
     ),
     "descriptionmyturn" => clienttranslate(
-      '${you} must remove ${nb} keepers for Keeper Limit ${limit}'
+      '${you} must remove ${_private.nb} keepers for Keeper Limit ${limit}'
     ),
     "type" => "multipleactiveplayer",
     "args" => "argKeeperLimit",


### PR DESCRIPTION
Allright, I think this should solve the remaining issues:
- correct "to discard" numbers per player using the _private feature
- addActionButton should only be called for active players in the multistate (others should see the "Other players must discard ..." message)
- Keepers should be discarded from the correct player's keeper stock, not from hand